### PR TITLE
Add CLI for ElasticNet and cleanup imports

### DIFF
--- a/elasticnet/cli.py
+++ b/elasticnet/cli.py
@@ -1,0 +1,75 @@
+import argparse
+import os
+import time
+import numpy as np
+
+from .io import (
+    run_cv_on_csv,
+    run_cv_on_directory,
+    run_repeated_cv_on_csv,
+    save_cv_diagnostic_plot,
+)
+from .cv_utils import pearson_corr
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ElasticNet CV utilities")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_once = subparsers.add_parser("once", help="Run cross-validated prediction on a CSV file")
+    p_once.add_argument("csv", help="Path to CSV file")
+
+    p_batch = subparsers.add_parser("batch", help="Run cross-validated prediction on all CSV files in a directory")
+    p_batch.add_argument("directory", help="Directory containing CSV files")
+
+    p_repeat = subparsers.add_parser("repeat", help="Repeated cross-validation on a CSV file")
+    p_repeat.add_argument("csv", help="Path to CSV file")
+    p_repeat.add_argument("repeats", type=int, help="Number of repetitions")
+
+    p_perm = subparsers.add_parser("permutation", help="Permutation testing via repeated CV")
+    p_perm.add_argument("csv", help="Path to CSV file")
+    p_perm.add_argument("repeats", type=int, help="Number of repetitions")
+
+    p_plot = subparsers.add_parser("plot", help="Generate diagnostic plot for a CSV file")
+    p_plot.add_argument("csv", help="Path to CSV file")
+
+    args = parser.parse_args()
+
+    if args.command == "once":
+        start = time.time()
+        r, p, e_time = run_cv_on_csv(args.csv)
+        print(f"r: {r}, p: {p}, time: {e_time}")
+        print_time(start)
+    elif args.command == "batch":
+        start = time.time()
+        results = run_cv_on_directory(args.directory)
+        results.to_csv("batch_test_result.csv")
+        print(results)
+        print_time(start)
+    elif args.command == "repeat":
+        start = time.time()
+        res = run_repeated_cv_on_csv(args.csv, n_repeats=args.repeats, shuffle_y=False)
+        np.save(os.path.splitext(args.csv)[0] + f"_repeat_{args.repeats}_cv_results.npy", res)
+        r, p = pearson_corr(res["mean_y_pred"], res["true_y"])
+        print(f"Mean predict y across {args.repeats} repeats, correlation is: {r}, {p}")
+        print_time(start)
+    elif args.command == "permutation":
+        start = time.time()
+        res = run_repeated_cv_on_csv(args.csv, n_repeats=args.repeats, shuffle_y=True)
+        np.save(os.path.splitext(args.csv)[0] + f"_permutation_{args.repeats}_results.npy", res)
+        r, p = pearson_corr(res["mean_y_pred"], res["true_y"])
+        print(f"Mean predict y across {args.repeats} repeats, correlation is: {r}, {p}")
+        print_time(start)
+    elif args.command == "plot":
+        save_cv_diagnostic_plot(args.csv)
+    else:
+        parser.print_help()
+
+
+def print_time(start):
+    e = int(time.time() - start)
+    print("Time elapsed:{:02d}:{:02d}:{:02d}".format(e // 3600, (e % 3600 // 60), e % 60))
+
+
+if __name__ == "__main__":
+    main()

--- a/elasticnet/io.py
+++ b/elasticnet/io.py
@@ -7,8 +7,7 @@ import time
 import numpy as np
 import pandas as pd
 from sklearn.model_selection import cross_val_predict
-from .estimator import ElasticNetCV
-from .cv_utils import corr_y, repeated_parallel_cv
+from .cv_utils import pearson_corr, repeated_parallel_cv
 
 
 def run_cv_on_csv(data_csv: str) -> tuple:
@@ -29,8 +28,6 @@ def run_cv_on_csv(data_csv: str) -> tuple:
     flag_col = np.array([idx for idx, col in enumerate(fs_df.columns) if 'flag' in col])
     fs = np.array(fs_df)
     from .estimator import GlmnetElasticNetCV
-    from .cv_utils import pearson_corr
-    from sklearn.model_selection import cross_val_predict
     clf = GlmnetElasticNetCV(not2preprocess=flag_col)
     y_pred = cross_val_predict(clf, fs, y, cv=10, n_jobs=-1)
     r_value, p_value = pearson_corr(y_pred, y)


### PR DESCRIPTION
## Summary
- add a command line interface for ElasticNet utilities
- fix missing imports in `elasticnet/io.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865d91ba3a88324b1cca07acbc154a6