### PR TITLE
Add classification support to estimators

### DIFF
--- a/cpm/cpm.py
+++ b/cpm/cpm.py
@@ -61,11 +61,29 @@ class SelectEdges(BaseEstimator, TransformerMixin):
 class CPM(BaseEstimator):
     """
     Sklearn‐style CPM with .fit/.predict and .explain for SHAP.
-    Internally uses SelectEdges + a linear model (default Ridge).
+    Internally uses SelectEdges + a linear model.
+
+    Parameters
+    ----------
+    threshold : float
+        Edge-selection p-value threshold.
+    estimator : sklearn estimator, optional
+        If None, Ridge is used for regression and LogisticRegression for
+        classification.
+    task : {'regression', 'classification'}
+        Type of prediction task.
     """
-    def __init__(self, threshold=0.01, estimator=None):
+    def __init__(self, threshold=0.01, estimator=None, task='regression'):
         self.threshold = threshold
-        self.estimator = estimator if estimator is not None else Ridge()
+        self.task = task
+        if estimator is not None:
+            self.estimator = estimator
+        else:
+            if self.task == 'classification':
+                from sklearn.linear_model import LogisticRegression
+                self.estimator = LogisticRegression(max_iter=1000)
+            else:
+                self.estimator = Ridge()
         self.selector = SelectEdges(threshold=self.threshold)
 
     def fit(self, X, y):

--- a/elasticnet/cli.py
+++ b/elasticnet/cli.py
@@ -18,50 +18,61 @@ def main():
 
     p_once = subparsers.add_parser("once", help="Run cross-validated prediction on a CSV file")
     p_once.add_argument("csv", help="Path to CSV file")
+    p_once.add_argument("--family", default="gaussian", help="glmnet family: gaussian, binomial, multinomial")
 
     p_batch = subparsers.add_parser("batch", help="Run cross-validated prediction on all CSV files in a directory")
     p_batch.add_argument("directory", help="Directory containing CSV files")
+    p_batch.add_argument("--family", default="gaussian", help="glmnet family")
 
     p_repeat = subparsers.add_parser("repeat", help="Repeated cross-validation on a CSV file")
     p_repeat.add_argument("csv", help="Path to CSV file")
     p_repeat.add_argument("repeats", type=int, help="Number of repetitions")
+    p_repeat.add_argument("--family", default="gaussian", help="glmnet family")
 
     p_perm = subparsers.add_parser("permutation", help="Permutation testing via repeated CV")
     p_perm.add_argument("csv", help="Path to CSV file")
     p_perm.add_argument("repeats", type=int, help="Number of repetitions")
+    p_perm.add_argument("--family", default="gaussian", help="glmnet family")
 
     p_plot = subparsers.add_parser("plot", help="Generate diagnostic plot for a CSV file")
     p_plot.add_argument("csv", help="Path to CSV file")
+    p_plot.add_argument("--family", default="gaussian", help="glmnet family")
 
     args = parser.parse_args()
 
     if args.command == "once":
         start = time.time()
-        r, p, e_time = run_cv_on_csv(args.csv)
+        r, p, e_time = run_cv_on_csv(args.csv, family=args.family)
         print(f"r: {r}, p: {p}, time: {e_time}")
         print_time(start)
     elif args.command == "batch":
         start = time.time()
-        results = run_cv_on_directory(args.directory)
+        results = run_cv_on_directory(args.directory, family=args.family)
         results.to_csv("batch_test_result.csv")
         print(results)
         print_time(start)
     elif args.command == "repeat":
         start = time.time()
-        res = run_repeated_cv_on_csv(args.csv, n_repeats=args.repeats, shuffle_y=False)
+        res = run_repeated_cv_on_csv(args.csv, n_repeats=args.repeats, shuffle_y=False, family=args.family)
         np.save(os.path.splitext(args.csv)[0] + f"_repeat_{args.repeats}_cv_results.npy", res)
-        r, p = pearson_corr(res["mean_y_pred"], res["true_y"])
-        print(f"Mean predict y across {args.repeats} repeats, correlation is: {r}, {p}")
+        if args.family == "gaussian":
+            r, p = pearson_corr(res["mean_y_pred"], res["true_y"])
+            print(f"Mean predict y across {args.repeats} repeats, correlation is: {r}, {p}")
+        else:
+            print(f"Mean accuracy across {args.repeats} repeats: {res['accuracy']}")
         print_time(start)
     elif args.command == "permutation":
         start = time.time()
-        res = run_repeated_cv_on_csv(args.csv, n_repeats=args.repeats, shuffle_y=True)
+        res = run_repeated_cv_on_csv(args.csv, n_repeats=args.repeats, shuffle_y=True, family=args.family)
         np.save(os.path.splitext(args.csv)[0] + f"_permutation_{args.repeats}_results.npy", res)
-        r, p = pearson_corr(res["mean_y_pred"], res["true_y"])
-        print(f"Mean predict y across {args.repeats} repeats, correlation is: {r}, {p}")
+        if args.family == "gaussian":
+            r, p = pearson_corr(res["mean_y_pred"], res["true_y"])
+            print(f"Mean predict y across {args.repeats} repeats, correlation is: {r}, {p}")
+        else:
+            print(f"Mean accuracy across {args.repeats} repeats: {res['accuracy']}")
         print_time(start)
     elif args.command == "plot":
-        save_cv_diagnostic_plot(args.csv)
+        save_cv_diagnostic_plot(args.csv, family=args.family)
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary
- extend `CPM` to optionally perform classification
- add classification capability to `GlmnetElasticNetCV`
- compute accuracy when `family` is binomial or multinomial
- expose family option on CLI utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865db19521883248804a4734951b00e